### PR TITLE
Added support for configurable file format

### DIFF
--- a/src/main/java/guru/nidi/ramlproxy/Application.java
+++ b/src/main/java/guru/nidi/ramlproxy/Application.java
@@ -45,7 +45,7 @@ public class Application {
                 .load(options.getRamlUri())
                 .assumingBaseUri(options.getBaseUri());
         final MultiReportAggregator aggregator = new MultiReportAggregator();
-        final Reporter reporter = new Reporter(options.getSaveDir());
+        final Reporter reporter = new Reporter(options.getSaveDir(), options.getFileFormat());
         final ServletHolder servlet = new ServletHolder(new TesterProxyServlet(options.getTarget(), definition, aggregator, reporter));
         servlet.setInitOrder(1);
         context.addServlet(servlet, "/*");

--- a/src/main/java/guru/nidi/ramlproxy/OptionContainer.java
+++ b/src/main/java/guru/nidi/ramlproxy/OptionContainer.java
@@ -19,6 +19,8 @@ import org.apache.commons.cli.*;
 
 import java.io.File;
 
+import guru.nidi.ramlproxy.Reporter.FileFormat;
+
 /**
  *
  */
@@ -28,6 +30,7 @@ public class OptionContainer {
     private File saveDir;
     private String ramlUri;
     private String baseUri;
+    private FileFormat fileFormat;
 
     public OptionContainer(String[] args) {
         final Options options = createOptions();
@@ -43,6 +46,8 @@ public class OptionContainer {
                 saveDir = new File(saveDirName);
                 saveDir.mkdirs();
             }
+            String fileFormatText = cmd.getOptionValue('f');
+            fileFormat =  fileFormatText != null ? FileFormat.valueOf(fileFormatText.toUpperCase()) : FileFormat.TEXT;
         } catch (Exception e) {
             System.out.println(e.getMessage());
             HelpFormatter formatter = new HelpFormatter();
@@ -51,6 +56,7 @@ public class OptionContainer {
         }
     }
 
+    @SuppressWarnings("static-access")
     private static Options createOptions() {
         final Options options = new Options();
         options.addOption(OptionBuilder.withDescription("The port to listen to").isRequired(true).withArgName("port").hasArg(true).create('p'));
@@ -58,6 +64,7 @@ public class OptionContainer {
         options.addOption(OptionBuilder.withDescription("RAML resource, possible schemas are classpath://, file://, http://, https://").isRequired(true).withArgName("URL").hasArg(true).create('r'));
         options.addOption(OptionBuilder.withDescription("Base URI that should be assumed").isRequired(false).withArgName("URI").hasArg(true).create('b'));
         options.addOption(OptionBuilder.withDescription("Save directory for failing requests/responses").isRequired(false).withArgName("directory").hasArg(true).create('s'));
+        options.addOption(OptionBuilder.withDescription("Format to use for report files, either text or json (defaults to text)").isRequired(false).withArgName("format").hasArg(true).create('f'));
         return options;
     }
 
@@ -79,5 +86,10 @@ public class OptionContainer {
 
     public String getBaseUri() {
         return baseUri;
+    }
+
+    public FileFormat getFileFormat()
+    {
+        return fileFormat;
     }
 }

--- a/src/main/java/guru/nidi/ramlproxy/Reporter.java
+++ b/src/main/java/guru/nidi/ramlproxy/Reporter.java
@@ -21,13 +21,19 @@ import guru.nidi.ramltester.core.Usage;
 import guru.nidi.ramltester.model.Values;
 import guru.nidi.ramltester.servlet.ServletRamlRequest;
 import guru.nidi.ramltester.servlet.ServletRamlResponse;
+
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
@@ -36,16 +42,57 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  */
 public class Reporter {
-    private static final byte[] NO_CONTENT = "No content".getBytes();
+
+    public static enum FileFormat {
+        TEXT("log") {
+            @Override
+            String formatUsage(Reporter reporter, String key, Map<String, Set<String>> unuseds) throws IOException {
+                return reporter.usageToString(unuseds);
+            }
+
+            @Override
+            String formatViolations(Reporter reporter, long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) throws IOException
+            {
+                return reporter.violationsToString(idValue, report, request, response);
+            }
+        },
+        JSON("json") {
+            @Override
+            String formatUsage(Reporter reporter, String key, Map<String, Set<String>> unuseds) throws IOException {
+                return reporter.usageToJson(key, unuseds);
+            }
+
+            @Override
+            String formatViolations(Reporter reporter, long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) throws IOException
+            {
+                return reporter.violationsToJson(idValue, report, request, response);
+            }
+        };
+
+        private final String fileExtension;
+
+        private FileFormat(String fileExtension) {
+            this.fileExtension=fileExtension;
+        }
+
+        abstract String formatUsage(Reporter reporter, String key, Map<String, Set<String>> unuseds) throws IOException;
+        abstract String formatViolations(Reporter reporter, long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) throws IOException;
+    };
+
+    private static final String NO_CONTENT = "No content";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final File saveDir;
+    private final FileFormat fileFormat;
     private final String startup = new SimpleDateFormat("yyyy-MM-dd_HH:mm:ss").format(new Date());
     private final AtomicLong id = new AtomicLong();
 
-    public Reporter(File saveDir) {
+    public Reporter(File saveDir, FileFormat fileFormat) {
         this.saveDir = saveDir;
+        this.fileFormat = fileFormat;
+        log.info("Reporting in " + fileFormat + " format into: " + saveDir);
     }
 
     public void reportViolations(RamlReport report, ServletRamlRequest request, ServletRamlResponse response) {
@@ -56,52 +103,66 @@ public class Reporter {
         }
     }
 
-    private void logViolations(RamlReport report, ServletRamlRequest request, long idValue) {
-        log.error("<{}> {}\n           Request:  {}\n           Response: {}", idValue, formatRequest(request), report.getRequestViolations(), report.getResponseViolations());
-    }
-
     public void reportUsage(MultiReportAggregator aggregator) {
         for (Map.Entry<String, Usage> entry : aggregator.usages()) {
             final Usage usage = entry.getValue();
-            final String s = unused(usage.getUnusedResources(), "resources")
-                    + unused(usage.getUnusedActions(), "actions")
-                    + unused(usage.getUnusedRequestHeaders(), "request headers")
-                    + unused(usage.getUnusedQueryParameters(), "query parameters")
-                    + unused(usage.getUnusedFormParameters(), "form parameters")
-                    + unused(usage.getUnusedResponseHeaders(), "response headers")
-                    + unused(usage.getUnusedResponseCodes(), "response codes");
-            logUsage(entry.getKey() + "\n" + s);
-            fileUsage(entry.getKey(), s);
+            final Map<String, Set<String>> unuseds = new HashMap<>();
+            unused(usage.getUnusedResources(), "resources", unuseds);
+            unused(usage.getUnusedActions(), "actions", unuseds);
+            unused(usage.getUnusedRequestHeaders(), "request headers", unuseds);
+            unused(usage.getUnusedQueryParameters(), "query parameters", unuseds);
+            unused(usage.getUnusedFormParameters(), "form parameters", unuseds);
+            unused(usage.getUnusedResponseHeaders(), "response headers", unuseds);
+            unused(usage.getUnusedResponseCodes(), "response codes", unuseds);
+            logUsage(entry.getKey(), unuseds);
+            fileUsage(entry.getKey(), unuseds);
         }
     }
 
-    private void fileUsage(String key, String s) {
+    private void fileUsage(String key, Map<String, Set<String>> unuseds) {
         if (saveDir == null) {
             return;
         }
         try {
-            final String filename = "raml-usage-" + startup + "--" + key.replace(" ", "-") + ".log";
+            final String filename = "raml-usage-" + startup + "--" + key.replace(" ", "-") + "." + fileFormat.fileExtension;
             try (OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(new File(saveDir, filename)), "utf-8")) {
-                out.write(s);
+                out.write(fileFormat.formatUsage(this, key, unuseds));
             }
         } catch (IOException e) {
             log.error("Problem writing error file", e);
         }
     }
 
-    private void logUsage(String s) {
-        log.error(s);
+    private void logUsage(String key, Map<String, Set<String>> unuseds) {
+        log.error(key + "\n" + usageToString(unuseds));
     }
 
-    private String unused(Set<String> values, String desc) {
-        if (values.isEmpty()) {
-            return "";
+    private String usageToString(Map<String, Set<String>> unuseds) {
+        final StringBuilder sb = new StringBuilder();
+        for (final Map.Entry<String, Set<String>> unused : unuseds.entrySet()) {
+            sb.append("  Unused ").append(unused.getKey()).append("\n");
+            for (final String value : unused.getValue()) {
+                sb.append("    ").append(value).append("\n");
+            }
         }
-        String res = "  Unused " + desc + "\n";
-        for (String value : new TreeSet<>(values)) {
-            res += "    " + value + "\n";
+        return sb.toString();
+    }
+
+    protected String usageToJson(String key, Map<String, Set<String>> unuseds) throws IOException {
+        Map<String,Object> json = new HashMap<>();
+        json.put("context", key);
+        json.put("unused", unuseds);
+        return OBJECT_MAPPER.writeValueAsString(json);
+    }
+
+    private void unused(Set<String> values, String desc, Map<String, Set<String>> acc) {
+        if (!values.isEmpty()) {
+            acc.put(desc, values);
         }
-        return res;
+    }
+
+    private void logViolations(RamlReport report, ServletRamlRequest request, long idValue) {
+        log.error("<{}> {}\n           Request:  {}\n           Response: {}", idValue, formatRequest(request), report.getRequestViolations(), report.getResponseViolations());
     }
 
     private void fileViolations(long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) {
@@ -109,19 +170,45 @@ public class Reporter {
             return;
         }
         try {
-            final String filename = "raml-violation-" + startup + "--" + idValue + ".log";
-            try (FileOutputStream out = new FileOutputStream(new File(saveDir, filename))) {
-                out.write(("Request violations: " + report.getRequestViolations() + "\n\n").getBytes());
-                out.write((formatRequest(request) + "\n").getBytes());
-                out.write((formatHeaders(request.getHeaderValues()) + "\n").getBytes());
-                out.write((request.getContent() == null ? NO_CONTENT : request.getContent()));
-                out.write(("\n\n\nResponse violations: " + report.getResponseViolations() + "\n\n").getBytes());
-                out.write((formatHeaders(response.getHeaderValues()) + "\n").getBytes());
-                out.write((response.getContent() == null ? NO_CONTENT : response.getContent()));
+            final String filename = "raml-violation-" + startup + "--" + idValue + "." + fileFormat.fileExtension;
+            try (OutputStreamWriter out = new OutputStreamWriter(new FileOutputStream(new File(saveDir, filename)))) {
+                out.write(fileFormat.formatViolations(this, idValue, report, request, response));
             }
         } catch (IOException e) {
             log.error("Problem writing error file", e);
         }
+    }
+
+    private String violationsToString(long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Request violations: ").append(report.getRequestViolations()).append("\n\n");
+        sb.append(formatRequest(request)).append("\n");
+        sb.append(formatHeaders(request.getHeaderValues())).append("\n");
+        sb.append(request.getContent() == null ? NO_CONTENT : new String(request.getContent(), encoding(request)));
+        sb.append("\n\n\nResponse violations: ").append(report.getResponseViolations()).append("\n\n");
+        sb.append(formatHeaders(response.getHeaderValues())).append("\n");
+        sb.append(response.getContent() == null ? NO_CONTENT : new String(response.getContent(), encoding(response)));
+        return sb.toString();
+    }
+
+    private String encoding(ServletRamlRequest request) {
+        return StringUtils.defaultIfBlank(request.getCharacterEncoding(), Charset.defaultCharset().name());
+    }
+
+    private String encoding(ServletRamlResponse response) {
+        return StringUtils.defaultIfBlank(response.getCharacterEncoding(), Charset.defaultCharset().name());
+    }
+
+    private String violationsToJson(long idValue, RamlReport report, ServletRamlRequest request, ServletRamlResponse response) throws IOException {
+        Map<String,Object> json = new HashMap<>();
+        json.put("id", idValue);
+        json.put("request violations", Lists.newArrayList(report.getRequestViolations()));
+        json.put("request", formatRequest(request));
+        json.put("request headers", request.getHeaderValues());
+        json.put("response violations", Lists.newArrayList(report.getResponseViolations()));
+        json.put("response", (response.getContent() == null ? NO_CONTENT : response.getContent()));
+        json.put("response headers", response.getHeaderValues());
+        return OBJECT_MAPPER.writeValueAsString(json);
     }
 
     private String formatRequest(ServletRamlRequest request) {


### PR DESCRIPTION
I've found it desirable to be able to parse the files produced by the proxy. The default format used for the `.log` file is not bad but not so easy to parse.

Therefore, I've added the possibility to ask the proxy to create `.json` files instead of `.log` via a new configuration option `-f`

The JSON rendering is a thin wrapper around the text format, it could be made better, but it's a start :wink: 
